### PR TITLE
use multi-stage build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
 FROM gcc:4.9
 
 RUN apt-get update && apt-get install -y qt5-qmake qt5-default git libboost-all-dev \
-zlib1g zlib1g-dev libqt5opengl5-dev unzip libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev mesa-utils
+  zlib1g zlib1g-dev libqt5opengl5-dev unzip libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev mesa-utils
 
 RUN mkdir dsistudio
-WORKDIR dsistudio 
+WORKDIR dsistudio
 RUN git clone -b master https://github.com/frankyeh/DSI-Studio.git src
 RUN wget https://github.com/frankyeh/TIPL/zipball/master
-RUN unzip master 
-RUN mv frankyeh-TIPL-* image
-RUN mv image src
+RUN unzip master
+RUN mv frankyeh-TIPL-* src/tipl
 
 RUN mkdir build
-WORKDIR build 
+WORKDIR build
 RUN qmake ../src && make
 
 WORKDIR ..
-RUN wget https://www.dropbox.com/s/ew3rv0jrqqny2dq/dsi_studio_64.zip?dl=1 
+RUN wget https://www.dropbox.com/s/ew3rv0jrqqny2dq/dsi_studio_64.zip?dl=1
 RUN mv dsi_studio_64.zip?dl=1 dsi_studio_64.zip
 RUN unzip dsi_studio_64.zip
 WORKDIR dsi_studio_64
@@ -26,3 +25,10 @@ RUN rm dsi_studio.exe
 RUN cp ../build/dsi_studio .
 
 CMD ./dsi_studio
+
+FROM debian:stretch-slim
+COPY --from=0 /dsistudio/dsi_studio_64 /opt/dsistudio
+RUN apt-get update -qq \
+  && apt-get install -qq --no-install-recommends -y \
+  qt5-default zlib1g libqt5opengl5 libglu1-mesa freeglut3
+CMD ["/opt/dsistudio/dsi_studio"]


### PR DESCRIPTION
This commit changes the Dockerfile to use a multi-stage build. In the second stage, we begin with a bare debian:stretch-slim base image, and the compiled dsistudio program is copied over. Runtime dependencies are also installed. This second stage ommits unnecessary build artifacts and compile-time dependencies that are not needed at runtime. This commit reduces the overall image size (uncompressed) from 2.6 GB to 427 MB.

In addition, the `TIPL` code is put under `src/tipl` instead of `src/image`. Compiling dsi studio with tipl in `src/image` would throw an error.